### PR TITLE
fortify.metaMDS failed if there were no species scores

### DIFF
--- a/R/fortify.metaMDS.R
+++ b/R/fortify.metaMDS.R
@@ -31,7 +31,7 @@
 `fortify.metaMDS` <- function(model, data, ...) {
     samp <- scores(model, display = "sites", ...)
     spp <- try(scores(model, display = "species", ...), silent = TRUE)
-    if (!is.null(spp) || !inherits(spp, "try-error")) {
+    if (!is.null(spp) && !inherits(spp, "try-error")) {
         out <- rbind(samp, spp)
         out <- data.frame(out, Score = factor(rep(c("sites","species"),
                                c(nrow(samp), nrow(spp)))),


### PR DESCRIPTION
This would fail because `autoplot`/`fortify` try to find species scores:

``` R
> library(ggvegan)
> data(dune)
> autoplot(metaMDS(vegdist(dune), trace = FALSE))
Error in data.frame(out, Score = factor(rep(c("sites", "species"), c(nrow(samp),  : 
  arguments imply differing number of rows: 21, 40, 20
```
